### PR TITLE
User 3.1 - Adjust ingredients in the shopping list

### DIFF
--- a/src/pages/ShoppingListPage.tsx
+++ b/src/pages/ShoppingListPage.tsx
@@ -1,4 +1,4 @@
-import { useShoppingList } from "../hooks/useShoppingList";
+// import { useShoppingList } from "../hooks/useShoppingList";
 import { Form, Button, ListGroup, Row, Col } from "react-bootstrap";
 import { useState } from "react";
 
@@ -9,9 +9,67 @@ ShoppingListPage.route = {
   protected: true,
 };
 
+// Future interface for useShoppingList could look like this
+
+//  interface ShoppingItem {
+//   id: number;
+//   userId: number;
+//   ingredient: string;
+//   checked: boolean;
+//   amount: number;
+//   unit: string;
+// }
+
 export default function ShoppingListPage() {
+  ////////////////////////////////////////
+  // MOCK UNTIL PROPER DB IS IMPLEMENTED//
+  function useShoppingListMock() {
+    const [items, setItems] = useState([
+      { id: "1", ingredient: "Eggs", checked: false, unit: "g", amount: "500" },
+      {
+        id: "2",
+        ingredient: "Milk",
+        checked: true,
+        unit: "ml",
+        amount: "1000",
+      },
+    ]);
+    ////////////////////////////////////////
+
+    const addItem = async (ingredient: string) => {
+      setItems((prev) => [
+        ...prev,
+        {
+          id: Math.random().toString(),
+          ingredient,
+          checked: false,
+          unit: "",
+          amount: "",
+        },
+      ]);
+    };
+
+    const removeItem = (id: string) => {
+      setItems((prev) => prev.filter((item) => item.id !== id));
+    };
+
+    const toggleItemChecked = (id: string, checked: boolean) => {
+      setItems((prev) =>
+        prev.map((item) => (item.id === id ? { ...item, checked } : item))
+      );
+    };
+
+    const fetchList = async () => {}; // no-op for mock
+
+    return { items, addItem, removeItem, toggleItemChecked, fetchList };
+  }
+
   const { items, addItem, removeItem, toggleItemChecked, fetchList } =
-    useShoppingList();
+    /////////////////////////////////////////////////
+    //Change this to useShoppingList when done mocking
+    /////////////////////////////////////////////////
+    useShoppingListMock();
+
   const [newItem, setNewItem] = useState("");
 
   async function handleAdd(e: React.FormEvent) {
@@ -23,19 +81,40 @@ export default function ShoppingListPage() {
   }
 
   return (
-    <Row className="mt-5 p-5">
-      <Col className="mt-4 mx-md-5 px-md-5">
+    <Row className="mt-5 p-3 p-xl-5">
+      <Col className="mt-4 mx-xl-5 px-xl-5">
         <h2>Shopping List</h2>
+        <Form onSubmit={handleAdd}>
+          <Row className="mt-4">
+            <Col xs={12} xl={7} className="mb-2">
+              <Form.Group>
+                <Form.Control
+                  placeholder="Add ingredient..."
+                  onChange={(e) => setNewItem(e.target.value)}
+                ></Form.Control>
+              </Form.Group>
+            </Col>
+            <Col xs={6} xl={3} className="mb-2">
+              <Form.Group>
+                <Form.Control
+                  placeholder="Add amount..."
+                  type="number"
+                  onChange={(e) => setNewItem(e.target.value)}
+                ></Form.Control>
+              </Form.Group>
+            </Col>
 
-        <Form onSubmit={handleAdd} className="d-flex my-3">
-          <Form.Control
-            placeholder="Add ingredient..."
-            value={newItem}
-            onChange={(e) => setNewItem(e.target.value)}
-          />
-          <Button variant="success" type="submit" className="ms-2">
-            Add
-          </Button>
+            <Col xs={6} xl={1}>
+              <Form.Control placeholder="Unit" disabled></Form.Control>
+            </Col>
+            <Col xs={12} xl={1}>
+              <div className="d-grid gap-2 mb-4 mb-xl-5">
+                <Button variant="success" type="submit" className="w-auto">
+                  Add
+                </Button>
+              </div>
+            </Col>
+          </Row>
         </Form>
 
         <ListGroup>
@@ -45,11 +124,19 @@ export default function ShoppingListPage() {
               className="d-flex align-items-center justify-content-between"
             >
               <Form.Check
+                id={`check-${item.id}`}
                 type="checkbox"
                 checked={item.checked}
                 onChange={(e) => toggleItemChecked(item.id, e.target.checked)}
-                label={item.ingredient}
+                label={
+                  <>
+                    {item.ingredient}
+                    <span className="ms-1">{item.amount}</span>
+                    <span className="ms-1">{item.unit}</span>
+                  </>
+                }
               />
+
               <Button
                 variant="outline-danger"
                 size="sm"


### PR DESCRIPTION
# User 3.1 - Adjust ingredients in the shopping list
Added a text box where the user can enter the desired amount of an ingredient. A read-only box has been added to display the ingredient’s unit, which will be populated automatically in the future based on the selected ingredient.

The ingredient’s amount and unit will also appear in the shopping list once the item is added.

Currently, the feature uses mock data for eggs and milk. It is not functional yet, as the implementation depends on the new database.

### Pull-request desktop:
<img width="1664" height="880" alt="image" src="https://github.com/user-attachments/assets/a7df68c8-e16f-4f3c-8875-6052232999c0" />

### Figma desktop:
<img width="1953" height="1797" alt="image" src="https://github.com/user-attachments/assets/552e02a6-5b84-42e4-a294-0e0e778225db" />

### Pull-request mobile:
<img width="304" height="632" alt="image" src="https://github.com/user-attachments/assets/4518d6e3-987a-4e20-bab1-b99498995d3b" />

### Pull-request  figma: 
<img width="392" height="908" alt="image" src="https://github.com/user-attachments/assets/4a0607ba-71eb-4d76-90e3-1170be21d7fb" />
